### PR TITLE
Use AssemblyTitle if no title is specified in a project template

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -82,7 +82,7 @@ them as below:
 The other general metadata properties are all optional, and map directly to the field of the same
 name in the nupkg.
 
-* title
+* title (Inferred as the value of the `AssemblyTitleAttribute` if omitted in a project template)
 * owners
 * releaseNotes
 * summary

--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -79,6 +79,11 @@ let getAuthors attributes =
             |> Array.map (fun s -> s.Trim())
             |> List.ofArray)
 
+let getTitle attributes = 
+    attributes |> Seq.tryPick (function 
+                      | Title t -> Some t
+                      | _ -> None) 
+
 let getDescription attributes = 
     attributes |> Seq.tryPick (function 
                       | Description d -> Some d

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -18,16 +18,22 @@ let private merge buildConfig buildPlatform version projectFile templateFile =
 
     match withVersion with
     | { Contents = ProjectInfo(md, opt) } -> 
+        let assembly,id,assemblyFileName = loadAssemblyId buildConfig buildPlatform projectFile
+        let attribs = loadAssemblyAttributes assemblyFileName assembly
+
+        let mergedOpt =
+            match opt.Title with
+            | Some _ -> opt
+            | None -> { opt with Title = getTitle attribs }
+
         match md with
-        | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, opt) }
+        | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, mergedOpt) }
         | _ ->
-            let assembly,id,assemblyFileName = loadAssemblyId buildConfig buildPlatform projectFile
             let md = { md with Id = md.Id ++ Some id }
 
             match md with
-            | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, opt) }
+            | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, mergedOpt) }
             | _ ->
-                let attribs = loadAssemblyAttributes assemblyFileName assembly
 
                 let merged = 
                     { Id = md.Id
@@ -51,7 +57,7 @@ let private merge buildConfig buildPlatform version projectFile templateFile =
                         Environment.NewLine md 
                         Environment.NewLine missing
 
-                | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, opt) }
+                | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, mergedOpt) }
     | _ -> templateFile
 
 let private convertToSymbols (projectFile : ProjectFile) templateFile =


### PR DESCRIPTION
As per issue #1281 if have updated the packing logic to use the AssemblyTitleAttribute value if not title is supplied in a project template file
